### PR TITLE
fix: Correct export for Setting model

### DIFF
--- a/models/setting.model.js
+++ b/models/setting.model.js
@@ -14,4 +14,4 @@ const settingSchema = new mongoose.Schema({
 
 const Setting = mongoose.model('Setting', settingSchema);
 
-module.exports = Setting;
+export default Setting;


### PR DESCRIPTION
- Change the export in `models/setting.model.js` to a default export to resolve the `SyntaxError: The requested module does not provide an export named 'default'` error.