### PR TITLE
fix(payment): correct payment verification logic

### DIFF
--- a/controllers/payment.controller.js
+++ b/controllers/payment.controller.js
@@ -34,7 +34,7 @@ const verifyPayment = asyncHandler(async (req, res) => {
     const response = await verifyTransaction(transactionReference);
 
     if (response.responseBody.paymentStatus === 'PAID') {
-        const booking = await Booking.findById(transactionReference);
+        const booking = await Booking.findById(response.responseBody.paymentReference);
         if (booking) {
             booking.status = 'confirmed';
             await booking.save();


### PR DESCRIPTION
The `verifyPayment` function was incorrectly using the `transactionReference` from the Monnify API response to look up the booking in the database. The `transactionReference` is Monnify's internal ID for the transaction.

This change corrects the logic to use the `paymentReference` from the Monnify response, which corresponds to the `bookingId` that was sent during the transaction initialization. This ensures that the correct booking is found and its status is updated after a successful payment.