### PR TITLE
fix: Handle missing Monnify contract code

### DIFF
--- a/controllers/payment.controller.js
+++ b/controllers/payment.controller.js
@@ -12,6 +12,10 @@ const makePayment = asyncHandler(async (req, res) => {
         throw new ApiError(404, 'Booking not found');
     }
 
+    if (!process.env.MONNIFY_CONTRACT_CODE) {
+        throw new ApiError(500, 'MONNIFY_CONTRACT_CODE is not defined in environment variables.');
+    }
+
     const data = {
         amount: booking.totalPrice,
         customerName: req.user.fullName,

--- a/services/payment.service.js
+++ b/services/payment.service.js
@@ -31,6 +31,10 @@ const getAuthToken = async () => {
 };
 
 const initializeTransaction = async (data) => {
+    if (!data.contractCode) {
+        throw new ApiError(400, 'contractCode is required to initialize a transaction.');
+    }
+
     try {
         const token = await getAuthToken();
         const response = await monnify.post('/merchant/transactions/init-transaction', data, {


### PR DESCRIPTION
Adds checks to ensure that the MONNIFY_CONTRACT_CODE environment variable is set before attempting to initialize a payment. This prevents a cryptic 'cannot be null' error and provides a clear error message instead.

- Added a check in `controllers/payment.controller.js` to ensure the environment variable is set.
- Added a validation check in `services/payment.service.js` to ensure the `contractCode` is present in the data passed to `initializeTransaction`.