### PR TITLE
Fix: Handle Monnify payment redirect without a frontend

### DIFF
--- a/routes/payment.routes.js
+++ b/routes/payment.routes.js
@@ -7,6 +7,8 @@ const router = Router();
 router.use(verifyJWT);
 
 router.route('/initialize/:bookingId').post(makePayment);
+router.route('/verify').get(verifyPayment);
 router.route('/verify/:transactionReference').get(verifyPayment);
+
 
 export default router;


### PR DESCRIPTION
When a `FRONTEND_URL` is not provided in the environment, the Monnify payment flow would get stuck on the success page because no `redirectUrl` was being passed to the payment initialization.

This commit addresses the issue by:
- Modifying `makePayment` to dynamically set the `redirectUrl` to a backend verification endpoint (`/api/v1/payments/verify`) if `FRONTEND_URL` is not set.
- Updating the `verifyPayment` controller to handle verification via a `paymentReference` passed as a query parameter from the Monnify redirect.
- Changing the `verifyPayment` response to show a simple HTML success page when no `FRONTEND_URL` is configured, providing feedback to the user.
- Enhancing the `verifyTransaction` service to robustly check for transactions using both the transaction reference and the payment reference, making the verification process more reliable.
- Updating the payment routes to support the new verification flow.