### PR TITLE
Fix: Remove auth middleware from payment verification route

### DIFF
--- a/routes/payment.routes.js
+++ b/routes/payment.routes.js
@@ -4,9 +4,7 @@ import { makePayment, verifyPayment } from '../controllers/payment.controller.js
 
 const router = Router();
 
-router.use(verifyJWT);
-
-router.route('/initialize/:bookingId').post(makePayment);
+router.route('/initialize/:bookingId').post(verifyJWT, makePayment);
 router.route('/verify').get(verifyPayment);
 router.route('/verify/:transactionReference').get(verifyPayment);
 


### PR DESCRIPTION
The payment verification route was protected by the `verifyJWT` authentication middleware. This caused an "Unauthorized request" error when Monnify redirected to the verification URL, as the redirect does not contain a user's JWT token.

This commit removes the `verifyJWT` middleware from the global payment router and applies it only to the `/initialize/:bookingId` route, which is the only one that requires an authenticated user session. The `/verify` routes are now public, allowing the Monnify redirect to work correctly.