### PR TITLE
Fix: Use correct endpoint for payment reference verification

### DIFF
--- a/services/payment.service.js
+++ b/services/payment.service.js
@@ -64,7 +64,7 @@ const verifyTransaction = async (reference) => {
         console.log("Failed to verify with transaction reference, trying with payment reference");
         try {
             const token = await getAuthToken();
-            const response = await monnify.get(`/transactions?paymentReference=${reference}`, {
+            const response = await monnify.get(`/transactions/by-payment-reference/${reference}`, {
                 headers: {
                     'Authorization': `Bearer ${token}`
                 }


### PR DESCRIPTION
The previous attempt to verify transactions by payment reference was failing with a 404 Not Found error. This was due to an incorrect API endpoint.

This commit updates the `verifyTransaction` function in `services/payment.service.js` to use a more likely endpoint for verifying by payment reference: `/transactions/by-payment-reference/{reference}`.

This is a speculative fix based on common REST API patterns, as the official documentation is unclear. This change is intended to resolve the "Failed to verify transaction" error.