### PR TITLE
Fix: Resolve PDF generation error

### DIFF
--- a/utils/pdfGenerator.js
+++ b/utils/pdfGenerator.js
@@ -1,5 +1,7 @@
-import jsPDF from 'jspdf';
-import 'jspdf-autotable';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const { jsPDF } = require('jspdf');
+require('jspdf-autotable');
 
 const generatePdfReceipt = (booking) => {
     const doc = new jsPDF();


### PR DESCRIPTION
This commit fixes a `TypeError: jsPDF is not a constructor` error that occurred during PDF receipt generation.

The error was caused by an ES Module/CommonJS interoperability issue with the `jspdf` library.

The fix implements a new import strategy using `createRequire` in `utils/pdfGenerator.js` to correctly import the `jspdf` library and its `jspdf-autotable` plugin. This ensures that the PDF generation is successful.