### PR TITLE
Fix: Refactor PDF generation to resolve library import issues

### DIFF
--- a/utils/pdfGenerator.js
+++ b/utils/pdfGenerator.js
@@ -1,7 +1,5 @@
-import { createRequire } from 'module';
-const require = createRequire(import.meta.url);
-const { jsPDF } = require('jspdf');
-require('jspdf-autotable');
+import jsPDF from 'jspdf';
+import autoTable from 'jspdf-autotable';
 
 const generatePdfReceipt = (booking) => {
     const doc = new jsPDF();
@@ -30,7 +28,7 @@ const generatePdfReceipt = (booking) => {
         `NGN ${booking.totalPrice}`
     ]];
 
-    doc.autoTable({
+    autoTable(doc, {
         startY: 95,
         head: [tableColumn],
         body: tableRows,


### PR DESCRIPTION
This commit refactors the PDF generation logic to fix critical errors related to ES Module/CommonJS interoperability with the `jspdf` and `jspdf-autotable` libraries.

The previous implementation caused `TypeError: jsPDF is not a constructor` and `TypeError: doc.autoTable is not a function` errors.

This fix addresses the root cause by:
1.  Using standard ES Module `import` statements for both `jspdf` and `jspdf-autotable`.
2.  Changing the `autotable` usage from a prototype method (`doc.autoTable`) to a direct function call (`autoTable(doc, ...)`).

This new implementation is more robust, follows modern JavaScript standards, and resolves the previously reported runtime errors, ensuring the PDF receipt is generated correctly.