### PR TITLE
Fix: Final attempt to resolve PDF generation errors

### DIFF
--- a/utils/pdfGenerator.js
+++ b/utils/pdfGenerator.js
@@ -1,5 +1,8 @@
-import jsPDF from 'jspdf';
+import { createRequire } from 'module';
 import autoTable from 'jspdf-autotable';
+
+const require = createRequire(import.meta.url);
+const { jsPDF } = require('jspdf');
 
 const generatePdfReceipt = (booking) => {
     const doc = new jsPDF();


### PR DESCRIPTION
This commit implements a hybrid import strategy to finally resolve the persistent `TypeError` exceptions encountered with `jspdf` and `jspdf-autotable` in an ES Module environment.

The previous attempts failed due to module interoperability issues, causing either `jsPDF is not a constructor` or `doc.autoTable is not a function` errors.

This fix combines two approaches:
1.  It uses `createRequire` to import `jspdf`, which correctly resolves the constructor issue.
2.  It uses a standard ESM `import` for `jspdf-autotable` and calls it functionally (`autoTable(doc, ...)`), which correctly applies the plugin.

This robust solution should ensure the PDF receipt generation works reliably.