### PR TITLE
Fix: Ensure PDF receipt is attached to confirmation email

### DIFF
--- a/services/email.service.js
+++ b/services/email.service.js
@@ -17,6 +17,7 @@ const sendEmail = async (options) => {
       to: options.email,
       subject: options.subject,
       html: options.html,
+      attachments: options.attachments,
     };
 
     await transporter.sendMail(mailOptions);


### PR DESCRIPTION
This commit fixes a bug where the generated PDF receipt was not being attached to the booking confirmation email.

The `sendEmail` service in `services/email.service.js` was not configured to handle attachments. The `mailOptions` object was missing the `attachments` property.

This fix adds `attachments: options.attachments` to the `mailOptions` object, ensuring that any attachments passed to the `sendEmail` service are correctly included in the outgoing email.