### PR TITLE
Fix: Convert PDF ArrayBuffer to Buffer for email attachment

### DIFF
--- a/controllers/payment.controller.js
+++ b/controllers/payment.controller.js
@@ -72,8 +72,10 @@ const verifyPayment = asyncHandler(async (req, res) => {
             booking.paymentStatus = 'paid';
             await booking.save();
 
-            // Generate PDF receipt
-            const pdfBuffer = generatePdfReceipt(booking);
+            // Generate PDF receipt as an ArrayBuffer
+            const pdfArrayBuffer = generatePdfReceipt(booking);
+            // Convert to a Node.js Buffer for nodemailer
+            const pdfBuffer = Buffer.from(pdfArrayBuffer);
 
             // Send confirmation email
             await sendEmail({


### PR DESCRIPTION
This commit fixes a bug that caused the email sending to fail with the error "The email could not be sent."

The root cause was an incompatibility between the `ArrayBuffer` format returned by `jspdf` and the `Buffer` format expected by `nodemailer` for attachments.

This fix introduces a conversion step in `controllers/payment.controller.js` that uses `Buffer.from()` to correctly format the PDF data before attaching it to the email. This ensures that the email can be sent successfully with the PDF receipt attached.